### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Awesome MCP FastAPI
 
+[![smithery badge](https://smithery.ai/badge/@MR-GREEN1337/awesome-mcp-fastapi)](https://smithery.ai/server/@MR-GREEN1337/awesome-mcp-fastapi)
+
 A powerful FastAPI-based implementation of the Model Context Protocol (MCP) with enhanced tool registry capabilities, leveraging the mature FastAPI ecosystem.
 
 ## Overview
@@ -41,6 +43,15 @@ Our implementation improves upon the standard MCP tool registry by:
 
 ### Installation
 
+#### Installing via Smithery
+
+To install Awesome MCP FastAPI for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@MR-GREEN1337/awesome-mcp-fastapi):
+
+```bash
+npx -y @smithery/cli install @MR-GREEN1337/awesome-mcp-fastapi --client claude
+```
+
+#### Manual Installation
 ```bash
 # Clone the repository
 git clone https://github.com/yourusername/awesome-mcp-fastapi.git

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - envFile
+    properties:
+      envFile:
+        type: string
+        description: Path to the .env file containing environment variables.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'docker', args: ['run', '-p', '8000:8000', '--env-file', config.envFile, 'awesome-mcp-fastapi'] })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@MR-GREEN1337/awesome-mcp-fastapi?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂